### PR TITLE
Fix signature payload comparison

### DIFF
--- a/src/Shared/Webhook/GithubWebhookParser.php
+++ b/src/Shared/Webhook/GithubWebhookParser.php
@@ -28,22 +28,26 @@ final class GithubWebhookParser extends AbstractRequestParser
 
     protected function doParse(Request $request, string $secret): ?RemoteEvent
     {
-        $payload = $request->toArray();
+        /** @var string $payload */
+        $payload = $request->getContent();
 
         $signatureFromPayload = $request->headers->get('X_HUB_SIGNATURE_256', null);
         if (null === $signatureFromPayload) {
             throw new RejectWebhookException(Response::HTTP_NOT_ACCEPTABLE, 'Signature is missing');
         }
 
-        /** @var string $payloadAsString */
-        $payloadAsString = json_encode($payload);
-        $signature = 'sha256='.hash_hmac('sha256', $payloadAsString, $this->webhookSecret);
+        $signature = 'sha256='.hash_hmac('sha256', $payload, $this->webhookSecret);
         if (!hash_equals($signature, $signatureFromPayload)) {
             throw new RejectWebhookException(Response::HTTP_FORBIDDEN, 'Access denied');
         }
 
-        $payload['event-type'] = $request->headers->get('X-GitHub-Event');
+        /** @var array<mixed> $payloadAsArray */
+        $payloadAsArray = json_decode($payload, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new RejectWebhookException(Response::HTTP_BAD_REQUEST, 'Error on json');
+        }
+        $payloadAsArray['event-type'] = $request->headers->get('X-GitHub-Event');
 
-        return new RemoteEvent('github.event', 'event-id', $payload);
+        return new RemoteEvent('github.event', 'event-id', $payloadAsArray);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix signature payload comparison
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | Trigger an github event with a wrong secret and check the logs. You should see a 403 response. If the secret is right the normal behaviour should occur
