### PR TITLE
Add retry configuration when calling github api

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -25,6 +25,12 @@ framework:
                 auth_bearer: '%env(KANBANBOT_TOKEN)%'
                 headers:
                     Accept: 'application/vnd.github.v3+json'
+                retry_failed:
+                    http_codes: [403, 408, 423, 425, 429, 500, 502, 503, 504, 507, 510]
+                    max_retries: 3
+                    delay: 1000
+                    multiplier: 2
+                    max_delay: 8000
 
     webhook:
         routing:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add configuration to permit the retry when calling the github api.<br>Retry 3 times in some http code cases:<br> - first after 1000 ms,<br>- then after 2000 ms,<br>- and finally after 4000 ms.<br><br>With 8000 ms limit max of delay.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #34175
| Sponsor company   | PrestaShop SA
| How to test?      | Nothing to really test here 😅
