### PR TITLE
Add new strategy for synchronize action on pull_request events

### DIFF
--- a/src/Shared/Infrastructure/Factory/CommandFactory/Strategy/Command/PullRequestSynchronizeStrategy.php
+++ b/src/Shared/Infrastructure/Factory/CommandFactory/Strategy/Command/PullRequestSynchronizeStrategy.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Factory\CommandFactory\Strategy\Command;
+
+use App\PullRequest\Application\Command\CheckTranslationsCommand;
+use App\Shared\Infrastructure\Factory\CommandFactory\CommandStrategyInterface;
+
+class PullRequestSynchronizeStrategy implements CommandStrategyInterface
+{
+    /**
+     * @param array{
+     *     action: string,
+     *     pull_request: array{
+     *          state: string
+     *     }
+     * } $payload
+     */
+    public function supports(string $eventType, array $payload): bool
+    {
+        return 'pull_request' === $eventType and 'synchronize' === $payload['action'] and 'open' === $payload['pull_request']['state'];
+    }
+
+    /**
+     * @param array{
+     *     pull_request: array{
+     *         base: array{
+     *             repo: array{
+     *                 name: string,
+     *                 owner: array{
+     *                     login: string
+     *                 }
+     *             }
+     *         },
+     *         number: int,
+     *     },
+     * } $payload
+     *
+     * @return array<CheckTranslationsCommand>
+     */
+    public function createCommandsFromPayload(array $payload): array
+    {
+        $repoOwner = $payload['pull_request']['base']['repo']['owner']['login'];
+        $repoName = $payload['pull_request']['base']['repo']['name'];
+        $prNumber = (string) $payload['pull_request']['number'];
+
+        return [
+            new CheckTranslationsCommand(
+                $repoOwner,
+                $repoName,
+                $prNumber
+            ),
+        ];
+    }
+}

--- a/tests/Shared/Infrastructure/Webhook/GithubWebhookTest.php
+++ b/tests/Shared/Infrastructure/Webhook/GithubWebhookTest.php
@@ -399,6 +399,50 @@ class GithubWebhookTest extends WebTestCase
                     ),
                 ],
             ],
+            [
+                'pull_request',
+                '{
+                    "action": "synchronize",
+                    "pull_request": {
+                        "base": {
+                            "repo": {
+                                "name": "repo",
+                                "owner": {
+                                    "login": "owner"
+                                }
+                            }
+                        },
+                        "state": "closed",
+                        "number": 123
+                    }
+                }',
+                [],
+            ],
+            [
+                'pull_request',
+                '{
+                    "action": "synchronize",
+                    "pull_request": {
+                        "base": {
+                            "repo": {
+                                "name": "repo",
+                                "owner": {
+                                    "login": "owner"
+                                }
+                            }
+                        },
+                        "state": "open",
+                        "number": 123
+                    }
+                }',
+                [
+                    new CheckTranslationsCommand(
+                        repositoryOwner: 'owner',
+                        repositoryName: 'repo',
+                        pullRequestNumber: '123'
+                    ),
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When we add a new commit on PR, we need to do some actions like checking new translations.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Push new branch and PR with new translations in it.<br> 2. Jarvis must comment your PR with theses translations.<br> 3. Push new commit with new translations.<br> 4. Jarvis must edit his previous comment with new translations.
