### PR TITLE
Add the possibility to set "n/a" for issues to disable issues needed

### DIFF
--- a/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
+++ b/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
@@ -143,6 +143,11 @@ class PullRequestDescription
 
     public function isLinkedIssuesNeeded(): bool
     {
+        // If "n/a" is found, it means that the PR doesn't need an issue anyway.
+        if ('n/a' === $this->extractWithRegex('Fixed issue or discussion')) {
+            return false;
+        }
+
         return in_array($this->getType(), ['bug fix', 'new feature']) && !in_array($this->getCategory(), ['TE', 'ME', 'PM']);
     }
 

--- a/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
+++ b/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
@@ -632,6 +632,23 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                     pullRequestNumber: 'fake'
                 ),
                 '
+                | Type?                          | new feature
+                | Category?                      | BO
+                | Fixed issue or discussion?     | n/a
+                ',
+                [],
+                [],
+                false,
+                true,
+                ['Feature'],
+            ],
+            [
+                new PullRequestId(
+                    repositoryOwner: 'PrestaShop',
+                    repositoryName: 'PrestaShop',
+                    pullRequestNumber: 'fake'
+                ),
+                '
                 | Branch?           | develop
                 | Description?      | Fake description 
                 | Type?             | new feature


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the possibility to set "n/a" for issues to disable issues needed
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| Sponsor company   | PrestaShop SA
| How to test?      | CI 🟢
