### PR TITLE
Fix Reopened status

### DIFF
--- a/src/PullRequestDashboard/Domain/Aggregate/PullRequestCard/PullRequestCard.php
+++ b/src/PullRequestDashboard/Domain/Aggregate/PullRequestCard/PullRequestCard.php
@@ -34,7 +34,7 @@ class PullRequestCard
 
     public function moveColumnByLabel(string $label): void
     {
-        if ('Waiting for author' === $label) {
+        if (in_array($label, ['Waiting for author', 'Reopened'])) {
             $this->columnName = $label;
         }
 

--- a/tests/PullRequestDashboard/Application/CommandHandler/MovePullRequestCardToColumnByLabelCommandHandlerTest.php
+++ b/tests/PullRequestDashboard/Application/CommandHandler/MovePullRequestCardToColumnByLabelCommandHandlerTest.php
@@ -25,6 +25,7 @@ class MovePullRequestCardToColumnByLabelCommandHandlerTest extends TestCase
     public static function handleDataProvider(): array
     {
         return [
+            ['Whatever column name', 'Reopened', 'Reopened'],
             ['Whatever column name', 'Waiting for author', 'Waiting for author'],
             ['Whatever column name', 'Waiting for PM', 'Waiting for PM/UX/Dev'],
             ['Whatever column name', 'Waiting for UX', 'Waiting for PM/UX/Dev'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When we close a PR, we change the status for PR Dashboard for this PR to `closed`. But if we reopen this PR, the status stay to `closed`. With this PR, we change the status to `reopened`.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | PrestaShop SA
| How to test?      | CI only
