### PR TITLE
Replace deprecated usage of ::set-output in Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-              echo "::set-output name=dir::$(composer config cache-files-dir)"
+              echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v4


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Replace deprecated usage of ::set-output in Github actions
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no