### PR TITLE
Stop re-posting the welcome message on every unmerged pull request

### DIFF
--- a/src/Shared/Infrastructure/Adapter/RestGithubCommitterRepository.php
+++ b/src/Shared/Infrastructure/Adapter/RestGithubCommitterRepository.php
@@ -32,16 +32,21 @@ class RestGithubCommitterRepository implements CommitterRepositoryInterface
             function (ItemInterface $item) use ($owner, $repo, $committer) {
                 $item->expiresAfter(60 * 60 * 6); // cache for 6 hours
 
-                $lastCommit = $this->githubClient->request('GET', '/repos/'.$owner.'/'.$repo.'/commits',
+                // A contributor is considered "new" while the current pull request is
+                // their only one in this repository. We rely on the search API so that
+                // still-open pull requests are taken into account: the /commits endpoint
+                // only returns merged contributions, which made the welcome message be
+                // re-posted on every new pull request as long as none had been merged.
+                $pullRequests = $this->githubClient->request('GET', '/search/issues',
                     [
                         'query' => [
-                            'author' => $committer,
+                            'q' => sprintf('repo:%s/%s type:pr author:%s', $owner, $repo, $committer),
                             'per_page' => 1,
                         ],
                     ]
                 )->toArray();
 
-                return 0 === count($lastCommit);
+                return ($pullRequests['total_count'] ?? 0) <= 1;
             }
         );
     }


### PR DESCRIPTION
## Problem

The welcome comment (`<!-- PR_WELCOME -->`, *"This is your first pull request"*) is re-posted on **every new pull request** of a contributor as long as **none** of their PRs has been merged — even when they already have several open.

Real example: [@PrestaEdit](https://github.com/PrestaShop/ui-testing-library/pulls/PrestaEdit) has 4 open PRs (none merged) on `ui-testing-library` and got the "first pull request" message on each one.

## Cause

`RestGithubCommitterRepository::isNewContributor()` used:

```php
GET /repos/{owner}/{repo}/commits?author={committer}&per_page=1
return 0 === count($lastCommit);
```

`GET /commits?author=` only returns commits on the default branch, i.e. those coming from **merged** PRs. So the real criterion was *"0 merged contribution"*, not *"first pull request"*. The dedup in `addWelcomeComment()` only checks the **current** PR, so nothing prevents a repost on the next PR.

## Fix

Detect a new contributor via the search API, counting pull requests **merged or not**:

```php
GET /search/issues?q=repo:{owner}/{repo}+type:pr+author:{committer}
return ($pullRequests['total_count'] ?? 0) <= 1;
```

A contributor is now welcomed only while the current PR is their only one in the repository. From their 2nd PR onward, the earlier (already indexed) PRs make `total_count >= 2` → no repost.

> Note: like any search-based check there is a brief indexing delay on a freshly opened PR; the existing 6h cache is preserved.

## How to test

The existing live-API tests in `RestGithubCommitterRepositoryTest` still hold:
- `boherm` (has PRs) → not new
- `new-contributor` (no PR) → new