### PR TITLE
Support GFM tables without leading pipes in PR description parsing

### DIFF
--- a/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
+++ b/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
@@ -151,7 +151,10 @@ class PullRequestDescription
         return in_array($this->getType(), ['bug fix', 'new feature']) && !in_array($this->getCategory(), ['TE', 'ME', 'PM']);
     }
 
-    private function extractWithRegex(string $field, string $patternValue = '[^|]*'): string
+    // Leading pipes are optional in GFM tables, so the answer cell must stop at the end
+    // of the line: with `[^|]*` a row like "Branch? | develop" (no leading pipe on the
+    // next row) would capture "develop\nDescription?" and fail validation.
+    private function extractWithRegex(string $field, string $patternValue = '[^|\r\n]*'): string
     {
         $regex = sprintf('~(?:\|?\s*%s\??\s+\|\s*)(%s)\s*~', $field, $patternValue);
         preg_match($regex, $this->bodyContent, $matches);

--- a/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
+++ b/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
@@ -708,6 +708,33 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                 false,
                 ['develop', 'Feature'],
             ],
+            // Leading pipes are optional in GFM tables: the table renders fine on GitHub
+            // and every answer must still be extracted (see PrestaShop/PrestaShop#41964).
+            [
+                new PullRequestId(
+                    repositoryOwner: 'PrestaShop',
+                    repositoryName: 'PrestaShop',
+                    pullRequestNumber: 'fake'
+                ),
+                '
+                **Questions** | **Answers**
+                ------------- | -------------
+                Branch? | develop
+                Description? | Fake description
+                Type? | improvement
+                Category? | CO
+                BC breaks? | no
+                Deprecations? | no
+                How to test? | Fake how to test
+                UI Tests | Fake UI tests
+                Fixed issue or discussion? | Fixes #123
+                ',
+                [],
+                [],
+                false,
+                false,
+                ['develop', 'Improvement'],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Bug

`PullRequestDescription::extractWithRegex()` captures the answer cell with `[^|]*`, which matches across newlines until the next pipe. This only works when every table row starts with a leading `|` (as in the current PR template). Leading pipes are **optional** in GitHub-flavored markdown, so on a perfectly valid table like:

```
Branch? | develop
Description? | ...
```

the Branch answer is captured as `develop\nDescription?`, every field fails validation, and the bot posts a table-errors comment on a valid PR.

Real-world occurrence: [this comment on PrestaShop/PrestaShop#41964](https://github.com/PrestaShop/PrestaShop/pull/41964#issuecomment-4890545177), where all five fields were reported invalid while the rendered table was correct.

## Fix

Stop the capture at the end of the line: `[^|]*` → `[^|\r\n]*`. Answer cells of a markdown table are single-line by definition, so this changes nothing for template-style tables (the previous capture already stopped at the next row's leading pipe and got trimmed to the same value) and fixes tables without leading pipes.

## Tests

Added a data-provider case in `CheckTableDescriptionCommandHandlerTest` with a pipe-less table: it fails on `main` (Branch/Type/Category/BC breaks/Deprecations all reported invalid) and passes with this change.

- `unit_tests`: OK (92 tests, 223 assertions)
- `endtoend_tests`: OK (139 tests, 292 assertions)
- `phpstan`: no errors
- `php-cs-fixer --dry-run`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)