### PR TITLE
Bootstrap CI for 9.2.x

### DIFF
--- a/src/PullRequest/Domain/Aggregate/PullRequest/PullRequest.php
+++ b/src/PullRequest/Domain/Aggregate/PullRequest/PullRequest.php
@@ -108,6 +108,7 @@ class PullRequest
         // Remove some labels in labels list
         $this->labels = array_diff($this->labels, [
             'develop',
+            '9.2.x',
             '8.1.x',
             '8.2.x',
             '9.0.x',

--- a/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
+++ b/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class PullRequestDescription
 {
-    public const TARGET_BRANCH_AVAILABLE = ['develop', '8.1.x', '8.2.x', '9.0.x', '9.1.x'];
+    public const TARGET_BRANCH_AVAILABLE = ['develop', '9.2.x', '8.1.x', '8.2.x', '9.0.x', '9.1.x'];
     public const TEMPLATE_DESCRIPTION = 'Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.';
     public const TYPES_AVAILABLE = ['bug fix', 'improvement', 'new feature', 'refacto'];
     public const CATEGORIES_AVAILABLE = ['FO', 'BO', 'CO', 'IN', 'WS', 'TE', 'LO', 'ME', 'PM'];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | main
| Description?      | Add the new version branch `9.2.x` (opened for 9.2.0) to this repository's CI matrices / branch lists.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Review the diff: `9.2.x` is added wherever active version branches are enumerated.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | Companion PRs opened by the same "Version-branch bootstrap" run.
| Sponsor company   | N/A

> 🤖 Opened automatically by the **Version-branch bootstrap** workflow. Idempotent: re-running updates this PR; if it was closed, a new one is created.