### PR TITLE
Update validation message for base branch in PullRequestDescription

### DIFF
--- a/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
+++ b/src/PullRequest/Domain/Aggregate/PullRequest/PullRequestDescription.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\PullRequest\Domain\Aggregate\PullRequest;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class PullRequestDescription
 {
-    public const TARGET_BRANCH_AVAILABLE = ['develop', '9.2.x', '8.1.x', '8.2.x', '9.0.x', '9.1.x'];
+    public const TARGET_BRANCH_AVAILABLE = ['develop', '9.2.x', '9.1.x', '8.2.x'];
     public const TEMPLATE_DESCRIPTION = 'Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.';
     public const TYPES_AVAILABLE = ['bug fix', 'improvement', 'new feature', 'refacto'];
     public const CATEGORIES_AVAILABLE = ['FO', 'BO', 'CO', 'IN', 'WS', 'TE', 'LO', 'ME', 'PM'];
@@ -20,7 +21,6 @@ class PullRequestDescription
     ) {
     }
 
-    #[Assert\NotBlank(message: 'The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))')]
     public function getBranch(): ?string
     {
         $branch = $this->extractWithRegex('Branch');
@@ -29,6 +29,35 @@ class PullRequestDescription
         }
 
         return null;
+    }
+
+    /**
+     * The available branches are listed in the error message, so it stays in sync with self::TARGET_BRANCH_AVAILABLE.
+     * A callback is needed here because an attribute argument can only be a constant expression.
+     */
+    #[Assert\Callback]
+    public function validateBranch(ExecutionContextInterface $context): void
+    {
+        if (null !== $this->getBranch()) {
+            return;
+        }
+
+        $context
+            ->buildViolation(self::getBranchErrorMessage())
+            ->atPath('branch')
+            ->addViolation();
+    }
+
+    public static function getBranchErrorMessage(): string
+    {
+        $branches = array_map(fn (string $branch) => sprintf('`%s`', $branch), self::TARGET_BRANCH_AVAILABLE);
+        $lastBranch = array_pop($branches);
+
+        return sprintf(
+            'The `branch` should be %s or %s. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
+            implode(', ', $branches),
+            $lastBranch
+        );
     }
 
     #[Assert\NotBlank(message: 'The `description` shouldn\'t be empty. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#description))')]

--- a/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
+++ b/tests/PullRequest/Application/CommandHandler/CheckTableDescriptionCommandHandlerTest.php
@@ -111,7 +111,7 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                 ),
                 '',
                 [
-                    'The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
+                    PullRequestDescription::getBranchErrorMessage(),
                     "The `description` shouldn't be empty. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#description))",
                     'The `type` should be one of these: `new feature`, `improvement`, `bug fix` or `refacto`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
                     'The `category` should be one of these: `FO`, `BO`, `CO`, `IN`, `WS`, `TE`, `LO`, `ME` or `PM`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
@@ -146,7 +146,7 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
 | Sponsor company   | Your company or customer's name goes here (if applicable).
 ",
                 [
-                    'The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
+                    PullRequestDescription::getBranchErrorMessage(),
                     "The `description` shouldn't be empty. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#description))",
                     'The `type` should be one of these: `new feature`, `improvement`, `bug fix` or `refacto`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
                     'The `category` should be one of these: `FO`, `BO`, `CO`, `IN`, `WS`, `TE`, `LO`, `ME` or `PM`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))',
@@ -166,7 +166,7 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                     pullRequestNumber: 'fake'
                 ),
                 '| Branch?           | fake',
-                ['The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))'],
+                [PullRequestDescription::getBranchErrorMessage()],
                 [],
                 false,
                 true,
@@ -180,7 +180,7 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                 ),
                 '| Branch?           | develop',
                 [],
-                ['The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))'],
+                [PullRequestDescription::getBranchErrorMessage()],
                 false,
                 true,
                 ['develop'],
@@ -191,9 +191,22 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                     repositoryName: 'PrestaShop',
                     pullRequestNumber: 'fake'
                 ),
+                '| Branch?           | 9.2.x',
+                [],
+                [PullRequestDescription::getBranchErrorMessage()],
+                false,
+                true,
+                ['9.2.x'],
+            ],
+            [
+                new PullRequestId(
+                    repositoryOwner: 'PrestaShop',
+                    repositoryName: 'PrestaShop',
+                    pullRequestNumber: 'fake'
+                ),
                 '| Branch?           | 9.1.x',
                 [],
-                ['The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))'],
+                [PullRequestDescription::getBranchErrorMessage()],
                 false,
                 true,
                 ['9.1.x'],
@@ -204,12 +217,13 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                     repositoryName: 'PrestaShop',
                     pullRequestNumber: 'fake'
                 ),
+                // 9.0.x is not maintained anymore, it should be rejected like any unknown branch.
                 '| Branch?           | 9.0.x',
+                [PullRequestDescription::getBranchErrorMessage()],
                 [],
-                ['The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))'],
                 false,
                 true,
-                ['9.0.x'],
+                [],
             ],
             [
                 new PullRequestId(
@@ -219,7 +233,7 @@ class CheckTableDescriptionCommandHandlerTest extends KernelTestCase
                 ),
                 '| Branch?           | 8.2.x',
                 [],
-                ['The `branch` should be `develop`, `9.1.x`, `9.0.x` or `8.2.x`. ([Read explanation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#branch))'],
+                [PullRequestDescription::getBranchErrorMessage()],
                 false,
                 true,
                 ['8.2.x'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Kanbanbot accepts `9.2.x` as a target branch in the PR description table, and the error message posted on the PR is now generated from `PullRequestDescription::TARGET_BRANCH_AVAILABLE` instead of being hardcoded. Previously the message listed `develop`, `9.1.x`, `9.0.x` and `8.2.x` and had to be edited by hand every time a version branch was opened or closed, so it was already out of sync with the actual list of allowed branches. Since an attribute argument must be a constant expression (no `implode()` allowed), the `#[Assert\NotBlank]` on `getBranch()` was replaced by an `#[Assert\Callback]` that builds the message at runtime through the new `getBranchErrorMessage()` and reports the violation on the same `branch` path. Behaviour of `getBranch()` is unchanged, so the automatic branch label still works the same way.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| Sponsor company   | PrestaShop
| How to test?      | Run `composer github-test` and `composer phpstan`: the `CheckTableDescriptionCommandHandlerTest` covers a PR description targeting `9.2.x` (no error, `9.2.x` label added) and an invalid branch (error raised). On a real PR against `PrestaShop/PrestaShop`, set `Branch?` to `9.2.x` in the description table: the bot must not complain about the branch and must add the `9.2.x` label. With an unknown branch, the comment must now list every branch of `TARGET_BRANCH_AVAILABLE`.
